### PR TITLE
fix: support exec via workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.11.0",
-        "hono": "^4.2.5",
-        "playwright-core": "^1.43.1",
-        "ws": "^8.16.0"
+        "@hono/node-server": "^1.13.7",
+        "hono": "^4.6.13",
+        "playwright-core": "^1.49.1",
+        "ws": "^8.18.0"
       },
       "bin": {
         "wet": "src/cli.js"
@@ -22,36 +22,43 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.11.0.tgz",
-      "integrity": "sha512-TLIJq9TMtD1NEG1mVoqNUn1Ita0qSaB5XboZErjFBcO/GJYXwWY4dVdTi9G0lbxtu0x+hJXDItcLaFHb7rlFTw==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.7.tgz",
+      "integrity": "sha512-kTfUMsoloVKtRA2fLiGSd9qBddmru9KadNyhJCwgKBxTiNkaAJEwkVN9KV/rS4HtmmNRtUh6P+YpmjRMl0d9vQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/hono": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.2.5.tgz",
-      "integrity": "sha512-uonJD3i/yy005kQ7bPZRVfG3rejYJwyPqBmPoUGijS4UB/qM+YlrZ7xzSWy+ByDu9buGHUG+f+SKzz03Y6V1Kw==",
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.13.tgz",
+      "integrity": "sha512-haV0gaMdSjy9URCRN9hxBPlqHa7fMm/T72kAImIxvw4eQLbNz1rgjN4hHElLJSieDiNuiIAXC//cC6YGz2KCbg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "dev": "node --watch --no-warnings src/cli.js"
   },
   "dependencies": {
-    "@hono/node-server": "^1.11.0",
-    "hono": "^4.2.5",
-    "playwright-core": "^1.43.1",
-    "ws": "^8.16.0"
+    "@hono/node-server": "^1.13.7",
+    "hono": "^4.6.13",
+    "playwright-core": "^1.49.1",
+    "ws": "^8.18.0"
   },
   "engines": {
     "node": ">=18.3.0"

--- a/src/release.js
+++ b/src/release.js
@@ -205,7 +205,7 @@ function log(msg, opts = {}) {
 }
 
 async function getpkg(key) {
-  const pkg = JSON.parse(await cmd(`npm pkg get`, {}));
+  const pkg = JSON.parse(await cmd(`npm pkg get --no-workspaces`, {}));
   return key ? pkg[key] : pkg;
 }
 


### PR DESCRIPTION
`--no-workspaces` has to be added so the result of npm pkg get
doesn't return a keyed map by package name instead of just the pkg json